### PR TITLE
Modify package name to com.launchdarkly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,8 @@ repositories {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
-    compile('com.launchdarkly:launchdarkly-android-client:2.5.1') {
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
+    implementation('com.launchdarkly:launchdarkly-android-client:2.5.1') {
         exclude group: 'com.squareup.okhttp', module: 'okhttp'
     }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.launchdarkly">
 
 </manifest>
   

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -40,7 +40,7 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void configure(String apiKey, ReadableMap options) {
+  public void configure(String apiKey, ReadableMap options, Promise promise) {
     LDConfig ldConfig = new LDConfig.Builder()
             .setMobileKey(apiKey)
             .build();
@@ -77,7 +77,9 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
     if (user != null && ldClient != null) {
       user = userBuilder.build();
       ldClient.identify(user);
-
+      WritableMap map = Arguments.createMap();
+      map.putString("email", options.getString("email"));
+      promise.resolve(map);
       return;
     }
 
@@ -87,8 +89,12 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
 
     if (reactActivity != null && reactActivity.getApplication() != null) {
       ldClient = LDClient.init(reactActivity.getApplication(), ldConfig, user, 0);
+      WritableMap map = Arguments.createMap();
+      map.putString("email", options.getString("email"));
+      promise.resolve(map);
     } else {
       Log.d("RNLaunchDarklyModule", "Couldn't init RNLaunchDarklyModule cause application was null");
+      promise.reject(new Throwable("Couldn't init RNLaunchDarklyModule cause application was null"));
     }
   }
 

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -70,7 +70,11 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
     while (iterator.hasNextKey()) {
       String key = iterator.nextKey();
       if (!nonCustomFields.contains(key)) {
-        userBuilder = userBuilder.custom(key, options.getString(key));
+        if (options.getType(key) == ReadableType.Number) {
+          userBuilder = userBuilder.custom(key, options.getDouble(key));
+        } else if (options.getType(key) == ReadableType.String) {
+          userBuilder = userBuilder.custom(key, options.getString(key));
+        }
         Log.d("RNLaunchDarklyModule", "Launch Darkly custom field: " + key);
       }
     }

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -82,9 +82,9 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
 
     user = userBuilder.build();
 
-    Application application = reactContext.getCurrentActivity().getApplication();
+    Activity reactActivity = reactContext.getCurrentActivity();
 
-    if (application != null) {
+    if (reactActivity && reactActivity.getApplication() != null) {
       ldClient = LDClient.init(application, ldConfig, user, 0);
     } else {
       Log.d("RNLaunchDarklyModule", "Couldn't init RNLaunchDarklyModule cause application was null");

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.launchdarkly;
 
 import android.app.Application;
 import android.util.Log;

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -6,6 +6,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -1,6 +1,7 @@
 
 package com.launchdarkly;
 
+import android.app.Activity;
 import android.app.Application;
 import android.util.Log;
 
@@ -84,8 +85,8 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
 
     Activity reactActivity = reactContext.getCurrentActivity();
 
-    if (reactActivity && reactActivity.getApplication() != null) {
-      ldClient = LDClient.init(application, ldConfig, user, 0);
+    if (reactActivity != null && reactActivity.getApplication() != null) {
+      ldClient = LDClient.init(reactActivity.getApplication(), ldConfig, user, 0);
     } else {
       Log.d("RNLaunchDarklyModule", "Couldn't init RNLaunchDarklyModule cause application was null");
     }

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyModule.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.common.collect.Sets;
 import com.launchdarkly.android.FeatureFlagChangeListener;

--- a/android/src/main/java/com/launchdarkly/RNLaunchDarklyPackage.java
+++ b/android/src/main/java/com/launchdarkly/RNLaunchDarklyPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.launchdarkly;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class LaunchDarkly {
   }
 
   configure (apiKey, options) {
-    RNLaunchDarkly.configure(apiKey, options);
+    return RNLaunchDarkly.configure(apiKey, options);
   }
 
   boolVariation (featureName, callback) {

--- a/ios/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly.m
@@ -9,7 +9,7 @@
     return @[@"FeatureFlagChanged"];
 }
 
-RCT_EXPORT_METHOD(configure:(NSString*)apiKey options:(NSDictionary*)options) {
+RCT_EXPORT_METHOD(configure:(NSString*)apiKey options:(NSDictionary*)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     NSLog(@"configure with %@", options);
 
     NSString* key           = options[@"key"];
@@ -53,6 +53,7 @@ RCT_EXPORT_METHOD(configure:(NSString*)apiKey options:(NSDictionary*)options) {
     if ( self.user ) {
         bool updatedSuccesfully = [[LDClient sharedInstance] updateUser:user];
         NSLog(@"LaunchDarkly User was updated. Key=%@ IsSuccess=%@", key, updatedSuccesfully ? @"YES" : @"NO");
+		resolve(@{ @"email": email});
         return;
     }
 
@@ -65,6 +66,7 @@ RCT_EXPORT_METHOD(configure:(NSString*)apiKey options:(NSDictionary*)options) {
      object:nil];
 
     [[LDClient sharedInstance] start:config userBuilder:user];
+	resolve(@{ @"email": email});
 }
 
 RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName callback:(RCTResponseSenderBlock)callback) {


### PR DESCRIPTION
`com.reactlibrary` is a common name found in other packages as well, and having the same name will cause conflict on Android:

    com.android.build.api.transform.TransformException: Error while generating the main dex list.
    > Error while generating the main dex list.
      > com.android.tools.r8.errors.CompilationError: Program type already present: 
    com.reactlibrary.BuildConfig
        > Program type already present: com.reactlibrary.BuildConfig

Issue: https://github.com/p-janik/react-native-launch-darkly/issues/11